### PR TITLE
Moved DataEncoder and DataDecoder protocols from vapor/core repo

### DIFF
--- a/Sources/CodableKit/DataCoder.swift
+++ b/Sources/CodableKit/DataCoder.swift
@@ -21,6 +21,21 @@ public protocol DataDecoder {
     func decode<D>(_ decodable: D.Type, from data: Data) throws -> D where D: Decodable
 }
 
+extension DataDecoder {
+    
+    /// Extracts the internal decoder for a public decoder type.
+    ///
+    ///     let decoder: Decoder = try JSONDecoder().decoder(with: data)
+    ///
+    /// - parameters:
+    ///   - data: The data that the decoder will hold
+    /// - returns: The internal decoder type.
+    /// - throws: Any error that may occur while parsing the data passed in.
+    public func decoder(with data: Data)throws -> Decoder {
+        return try self.decode(DecoderUnwrapper.self, from: data).decoder
+    }
+}
+
 /// A type capable of encoding `Encodable` objects to `Data`.
 ///
 ///     print(user) /// User
@@ -45,10 +60,36 @@ public protocol DataEncoder {
 public protocol DataCoder: DataEncoder, DataDecoder {}
 
 /// MARK: Default Conformances
-extension JSONDecoder: DataDecoder { }
 extension JSONEncoder: DataEncoder { }
+extension JSONDecoder: DataDecoder {
+    
+    /// Extracts the internal decoder for a public decoder type.
+    ///
+    ///     let decoder: Decoder = try JSONDecoder.decoder(with: data)
+    ///
+    /// - parameters:
+    ///   - data: The data that the decoder will hold
+    /// - returns: The internal decoder type.
+    /// - throws: Any error that may occur while parsing the data passed in.
+    public static func decoder(with data: Data)throws -> Decoder {
+        return try JSONDecoder().decode(DecoderUnwrapper.self, from: data).decoder
+    }
+}
 
 #if os(macOS)
-extension PropertyListDecoder: DataDecoder { }
 extension PropertyListEncoder: DataEncoder { }
+extension PropertyListDecoder: DataDecoder {
+    
+    /// Extracts the internal decoder for a public decoder type.
+    ///
+    ///     let decoder: Decoder = try JSONDecoder.decoder(with: data)
+    ///
+    /// - parameters:
+    ///   - data: The data that the decoder will hold
+    /// - returns: The internal decoder type.
+    /// - throws: Any error that may occur while parsing the data passed in.
+    public static func decoder(with data: Data)throws -> Decoder {
+        return try PropertyListDecoder().decode(DecoderUnwrapper.self, from: data).decoder
+    }
+}
 #endif

--- a/Sources/CodableKit/DataCoder.swift
+++ b/Sources/CodableKit/DataCoder.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// A type capable of decoding `Decodable` types from `Data`.
+///
+///     print(data) /// Data
+///     let user = try JSONDecoder().decode(User.self, from: data)
+///     print(user) /// User
+///
+public protocol DataDecoder {
+    /// Decodes an instance of the supplied `Decodable` type from `Data`.
+    ///
+    ///     print(data) /// Data
+    ///     let user = try JSONDecoder().decode(User.self, from: data)
+    ///     print(user) /// User
+    ///
+    /// - parameters:
+    ///     - decodable: Generic `Decodable` type (`D`) to decode.
+    ///     - from: `Data` to decode a `D` from.
+    /// - returns: An instance of the `Decodable` type (`D`).
+    /// - throws: Any error that may occur while attempting to decode the specified type.
+    func decode<D>(_ decodable: D.Type, from data: Data) throws -> D where D: Decodable
+}
+
+/// A type capable of encoding `Encodable` objects to `Data`.
+///
+///     print(user) /// User
+///     let data = try JSONEncoder().encode(user)
+///     print(data) /// Data
+///
+public protocol DataEncoder {
+    /// Encodes the supplied `Encodable` object to `Data`.
+    ///
+    ///     print(user) /// User
+    ///     let data = try JSONEncoder().encode(user)
+    ///     print(data) /// Data
+    ///
+    /// - parameters:
+    ///     - encodable: Generic `Encodable` object (`E`) to encode.
+    /// - returns: Encoded `Data`
+    /// - throws: Any error taht may occur while attempting to encode the specified type.
+    func encode<E>(_ encodable: E) throws -> Data where E: Encodable
+}
+
+/// A type capable of encoding `Encodable` objects to `Data` and decoding `Data` to `Decodable` objects.
+public protocol DataCoder: DataEncoder, DataDecoder {}
+
+/// MARK: Default Conformances
+extension JSONDecoder: DataDecoder { }
+extension JSONEncoder: DataEncoder { }
+
+extension PropertyListDecoder: DataDecoder { }
+extension PropertyListEncoder: DataEncoder { }

--- a/Sources/CodableKit/DataCoder.swift
+++ b/Sources/CodableKit/DataCoder.swift
@@ -48,5 +48,7 @@ public protocol DataCoder: DataEncoder, DataDecoder {}
 extension JSONDecoder: DataDecoder { }
 extension JSONEncoder: DataEncoder { }
 
+#if os(macOS)
 extension PropertyListDecoder: DataDecoder { }
 extension PropertyListEncoder: DataEncoder { }
+#endif

--- a/Sources/CodableKit/DataCoder.swift
+++ b/Sources/CodableKit/DataCoder.swift
@@ -31,7 +31,7 @@ extension DataDecoder {
     ///   - data: The data that the decoder will hold
     /// - returns: The internal decoder type.
     /// - throws: Any error that may occur while parsing the data passed in.
-    public func decoder(with data: Data)throws -> Decoder {
+    public func decoder(from data: Data) throws -> Decoder {
         return try self.decode(DecoderUnwrapper.self, from: data).decoder
     }
 }
@@ -71,7 +71,7 @@ extension JSONDecoder: DataDecoder {
     ///   - data: The data that the decoder will hold
     /// - returns: The internal decoder type.
     /// - throws: Any error that may occur while parsing the data passed in.
-    public static func decoder(with data: Data)throws -> Decoder {
+    public static func decoder(from data: Data) throws -> Decoder {
         return try JSONDecoder().decode(DecoderUnwrapper.self, from: data).decoder
     }
 }
@@ -88,7 +88,7 @@ extension PropertyListDecoder: DataDecoder {
     ///   - data: The data that the decoder will hold
     /// - returns: The internal decoder type.
     /// - throws: Any error that may occur while parsing the data passed in.
-    public static func decoder(with data: Data)throws -> Decoder {
+    public static func decoder(from data: Data) throws -> Decoder {
         return try PropertyListDecoder().decode(DecoderUnwrapper.self, from: data).decoder
     }
 }

--- a/Sources/CodableKit/DataCoder.swift
+++ b/Sources/CodableKit/DataCoder.swift
@@ -57,7 +57,7 @@ public protocol DataEncoder {
 }
 
 /// A type capable of encoding `Encodable` objects to `Data` and decoding `Data` to `Decodable` objects.
-public protocol DataCoder: DataEncoder, DataDecoder {}
+public typealias DataCoder: DataEncoder & DataDecoder
 
 /// MARK: Default Conformances
 extension JSONEncoder: DataEncoder { }

--- a/Sources/CodableKit/DataCoder.swift
+++ b/Sources/CodableKit/DataCoder.swift
@@ -57,7 +57,7 @@ public protocol DataEncoder {
 }
 
 /// A type capable of encoding `Encodable` objects to `Data` and decoding `Data` to `Decodable` objects.
-public typealias DataCoder: DataEncoder & DataDecoder
+public typealias DataCoder = DataEncoder & DataDecoder
 
 /// MARK: Default Conformances
 extension JSONEncoder: DataEncoder { }


### PR DESCRIPTION
Relocates the `DataEncoder` and `DataDecoder` protocols from the vapor/core repo to the CodableKit package with a couple minor changes:

- `DataDecoder` doesn't have a `decode` method that takes in `LosslessDataConvertible`. That protocol is not available in this package.
- Adds a `DataCoder` protocol that implements the `DataDecoder` and `DataEncoder` protocols. Not sure if it's needed, but it was only one line so I figured it wouldn't hurt.
- Conforms `PropertyListDecoder` to `DataDecoder` and `PropertyListEncoder` to `DataEncoder`.