### PR TITLE
add wrapper helpers + basic key type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.build
 /Packages
 /*.xcodeproj
+DerivedData
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,14 @@
-// swift-tools-version:4.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
-    name: "CodableKit",
+    name: "codable-kit",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "CodableKit",
-            targets: ["CodableKit"]),
+        .library(name: "CodableKit", targets: ["CodableKit"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "CodableKit",
-            dependencies: []),
-        .testTarget(
-            name: "CodableKitTests",
-            dependencies: ["CodableKit"]),
+        .target(name: "CodableKit", dependencies: []),
+        .testTarget(name: "CodableKitTests", dependencies: ["CodableKit"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 # CodableKit
-
-A description of this package.

--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -1,3 +1,0 @@
-struct CodableKit {
-    var text = "Hello, World!"
-}

--- a/Sources/CodableKit/DecoderUnwrapper.swift
+++ b/Sources/CodableKit/DecoderUnwrapper.swift
@@ -1,0 +1,14 @@
+/// Used to unwrap the `Decoder` from a private implementation like `JSONDecoder`.
+///
+///     let unwrapper = try JSONDecoder().decode(DecoderUnwrapper.self, from: ...)
+///     print(unwrapper.decoder) // Decoder
+///
+public struct DecoderUnwrapper: Decodable {
+    /// The unwrapped `Decoder`.
+    public let decoder: Decoder
+    
+    /// `Decodable` conformance.
+    public init(from decoder: Decoder) {
+        self.decoder = decoder
+    }
+}

--- a/Sources/CodableKit/EncodableWrapper.swift
+++ b/Sources/CodableKit/EncodableWrapper.swift
@@ -1,0 +1,20 @@
+/// Wraps a non-generic `Encodable` type for passing to a method that requires
+/// a strong type.
+///
+///     let encodable: Encodable ...
+///     let data = try JSONEncoder().encode(EncodableWrapper(encodable))
+///
+public struct EncodableWrapper: Encodable {
+    /// Wrapped `Encodable` type.
+    public let encodable: Encodable
+    
+    /// Creates a new `EncoderWrapper`.
+    public init(_ encodable: Encodable) {
+        self.encodable = encodable
+    }
+    
+    /// `Encodable` conformance.
+    public func encode(to encoder: Encoder) throws {
+        try self.encodable.encode(to: encoder)
+    }
+}

--- a/Sources/CodableKit/StringCodingKey.swift
+++ b/Sources/CodableKit/StringCodingKey.swift
@@ -1,0 +1,25 @@
+/// A generic `String` based `CodingKey` implementation.
+public struct StringCodingKey: CodingKey {
+    /// `CodingKey` conformance.
+    public var stringValue: String
+    
+    /// `CodingKey` conformance.
+    public var intValue: Int? {
+        return Int(self.stringValue)
+    }
+    
+    /// Creates a new `StringCodingKey`.
+    public init(_ string: String) {
+        self.stringValue = string
+    }
+    
+    /// `CodingKey` conformance.
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+    
+    /// `CodingKey` conformance.
+    public init?(intValue: Int) {
+        self.stringValue = intValue.description
+    }
+}

--- a/Tests/CodableKitTests/CodableKitTests.swift
+++ b/Tests/CodableKitTests/CodableKitTests.swift
@@ -1,15 +1,22 @@
 import XCTest
-@testable import CodableKit
+import Foundation
+import CodableKit
 
 final class CodableKitTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(CodableKit().text, "Hello, World!")
+    func testDecoderUnwrapper() throws {
+        let data = "{}".data(using: .utf8)!
+        let unwrapper = try JSONDecoder().decode(DecoderUnwrapper.self, from: data)
+        print(unwrapper.decoder) // Decoder
+    }
+    
+    func testEncodableWrapper() throws {
+        let encodable: Encodable = ["hello": "world"]
+        let data = try JSONEncoder().encode(EncodableWrapper(encodable))
+        print(data)
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testDecoderUnwrapper", testDecoderUnwrapper),
+        ("testEncodableWrapper", testEncodableWrapper),
     ]
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+version: 2
+
+jobs:
+  linux:
+    docker:
+      - image: vapor/swift:5.0
+    steps:
+      - checkout
+      - run: swift build
+      - run: swift test
+  linux-release:
+    docker:
+      - image: vapor/swift:5.0
+    steps:
+      - checkout
+      - run: swift build -c release
+workflows:
+  version: 2
+  tests:
+    jobs:
+      - linux
+      - linux-release
+


### PR DESCRIPTION
- [x] Adds `DecoderUnwrapper`

```swift
let data = "{}".data(using: .utf8)!
let unwrapper = try JSONDecoder().decode(DecoderUnwrapper.self, from: data)
print(unwrapper.decoder) // Decoder
```

- [x] Adds `EncodableWrapper`

```swift
let encodable: Encodable = ["hello": "world"]
let data = try JSONEncoder().encode(EncodableWrapper(encodable))
print(data)
```

- [x] Adds `StringCodingKey`

Basic `String` conformance to `CodingKey`. 